### PR TITLE
fix: typo

### DIFF
--- a/cryptopunks/lib/cryptopunks/image.rb
+++ b/cryptopunks/lib/cryptopunks/image.rb
@@ -53,7 +53,7 @@ def initialize( initial=nil, design: nil,
                              colors: nil )
     if initial
       ## pass image through as-is
-      img = inital
+      img = initial
     else
 
       ## todo/fix:


### PR DESCRIPTION
There is a typo in `Image#initialize` and as a result it crashes.